### PR TITLE
Update ee.c

### DIFF
--- a/ee.c
+++ b/ee.c
@@ -189,7 +189,7 @@ bool ee_format(bool keepRamData)
   FLASH_EraseInitTypeDef flashErase;
 #if _EE_PAGE_OR_SECTOR == PAGE
 	flashErase.NbPages = 1;
-  flashErase.PageAddress = _EE_ADDR_INUSE;
+  flashErase.PageAddress = _EE_USE_FLASH_PAGE_OR_SECTOR;
   flashErase.TypeErase = FLASH_TYPEERASE_PAGES;
 #elif _EE_PAGE_OR_SECTOR == SECTOR
   flashErase.NbSectors = 1;


### PR DESCRIPTION
Use case stm32L4 
HAL_FLASHEx_Erase was throwing error because flashErase.Page needs to be between 0-255

This is from stm32L4xx_hal_flash.h
  uint32_t Page;        /*!< Initial Flash page to erase when page erase is disabled
                             This parameter must be a value between 0 and (max number of pages in the bank - 1)
                             (eg : 255 for 1MB dual bank) */